### PR TITLE
changed default value for total_pages

### DIFF
--- a/tap_paypal/paypal.py
+++ b/tap_paypal/paypal.py
@@ -168,7 +168,7 @@ class PayPal(object):  # noqa: WPS230
 
                 # Retrieve the current page details
                 page = response_data.get('page', 1)
-                total_pages = response_data.get('total_pages', 0)
+                total_pages = response_data.get('total_pages', 1)
 
                 percentage_page: float = round((page / total_pages) * 100, 2)
                 percentage_batch: float = round(


### PR DESCRIPTION
with a default value of 0 you would get a ZeroDivisionError in line 173, when dividing by total_pages